### PR TITLE
Fix SSE goroutine cleanup

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -336,11 +336,8 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	// Write response
 	mu.Lock()
 	defer mu.Unlock()
-	// close the done chan before unlock
-	if !session.upgradeToSSE.Load() {
-		defer close(done)
-	}
-	// defer close(done)
+	// ensure the notification goroutine stops once the response has been sent
+	defer close(done)
 	if ctx.Err() != nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- ensure the notification goroutine is stopped for all POST requests
- do not leave it running when SSE is used

## Testing
- `go test ./...` *(fails: github.com/spf13/cast v1.7.1: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874a2f53ef88328af9f29eeed779467